### PR TITLE
Update for Chrome print to PDF.

### DIFF
--- a/assets/remark_template.html
+++ b/assets/remark_template.html
@@ -8,6 +8,16 @@
       @import url(https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic);
       @import url(https://fonts.googleapis.com/css?family=Ubuntu+Mono:400,700,400italic);
 
+      @media print {
+          .remark-slide-scaler {
+              width: 100% !important;
+              height: 100% !important;
+              transform: scale(1) !important;
+              top: 0 !important;
+              left: 0 !important;
+          }
+      }
+
       body { font-family: 'Droid Serif'; }
       h1, h2, h3 {
         font-family: 'Yanone Kaffeesatz';
@@ -26,6 +36,18 @@ REPLACE_ME
     </script>
     <script>
       var slideshow = remark.create();
+
+      /**
+        Set the page attribute dynamically, as needed for printing to PDF.
+       **/
+      (function() {
+          var d = document, s = d.createElement("style"), r = d.querySelector(".remark-slide-scaler");
+          if (!r) return;
+          s.type = "text/css";
+          s.innerHTML = "@page { size: " + r.style.width + " " + r.style.height +"; }";
+          d.head.appendChild(s);
+      })();
+
     </script>
   </body>
 </html>


### PR DESCRIPTION
This just updates the template to help print to PDF on chrome (see https://github.com/gnab/remark/issues/50).

Comparison:

<img width="914" alt="before-print" src="https://user-images.githubusercontent.com/10038688/44957656-2315e900-aecc-11e8-9883-348e389ea8ff.PNG">
<img width="901" alt="after-print" src="https://user-images.githubusercontent.com/10038688/44957657-24471600-aecc-11e8-8c33-204e1e61f5e9.PNG">

As another thing, is there a way/ do you mind if a config var is added to set a custom template?
Added this as a PR since it helps everyone/doesn't change the look of the presentations at all, but for more opinionated stuff it makes more sense to point to a custom config.

EDIT: I've done a branch in my fork for a custom config, and for dynamically setting the title based on the first `# XXX` appearance, so the tab title when you open the presentation is correct.